### PR TITLE
repair slant svg in section b3

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,8 +155,10 @@
               </li>
     </ul>
   </section>
-  <svg></svg>
     <section class="b3-support-reviews" id="#reviews">
+    <svg class="slant" xmlns="http://www.w3.org/2000/svg" version="1.1" width="100%" height="100" viewBox="0 0 100 102" preserveAspectRatio="none">
+      <path d="M0 0 L0 100 L100 0 Z" />
+    </svg>
       <div class="reviews-container">
         <span class="icon-rightquote"></span>
         <div class="half-container-icon"></div>


### PR DESCRIPTION
Fixed bug created by last merge, slant separator is now displaying correctly.
